### PR TITLE
Add missing use statements for annotations

### DIFF
--- a/Controller/JavascriptController.php
+++ b/Controller/JavascriptController.php
@@ -7,6 +7,8 @@ use Hatimeria\ExtJSBundle\DependencyInjection\HatimeriaExtJSExtension;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Assetic\Asset\FileAsset;
 use Assetic\Asset\AssetCollection;
+use Hatimeria\ExtJSBundle\Annotation\Remote;
+use Hatimeria\ExtJSBundle\Annotation\Form;
 
 /**
  * Javascript controller


### PR DESCRIPTION
Else the annotations parser was throwing an exception about unimported annotations.
