### PR TITLE
preg_replace => preg_replace_callback

### DIFF
--- a/Util/Camelizer.php
+++ b/Util/Camelizer.php
@@ -11,6 +11,6 @@ class Camelizer
 {
     public function camelize($key)
     {
-        return lcfirst(preg_replace('/(^|_|-)+(.)/e', "strtoupper('\\2')", $key));
+        return lcfirst(preg_replace_callback('/(^|_|-)+(.)/', function($m) { return strtoupper($m[2]); }, $key));
     }
 }


### PR DESCRIPTION
`\Hatimeria\ExtJSBundle\Util\Camelizer::camelize` fix to solve the issue

```
8192: preg_replace(): The /e modifier is deprecated, use preg_replace_callback instead in /vendor/bundles/Hatimeria/ExtJSBundle/Util/Camelizer.php line 14
```
